### PR TITLE
chore: add GitHub templates for Issues and Pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: 🐛 Bug report
+about: Create a report if something isn't working as expected
+labels: bug
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+## 🐛 Bug Report
+
+<!-- A clear and concise description of what the bug is. -->
+
+## To reproduce
+
+Steps to reproduce the behavior:
+
+## Expected behavior
+
+<!-- A clear and concise description of what you expected to happen. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,18 @@
+---
+name: 🚀 Feature Proposal
+about: Submit a proposal for a new feature
+---
+
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+## 🚀 Feature Proposal
+
+<!-- A clear and concise description of what the feature is. -->
+
+## Motivation
+
+<!-- Please outline the motivation for the proposal. -->
+
+## Example
+
+<!-- Please provide an example for how this feature would be used. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
+
+## Summary
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+
+<!-- If this pull request fixes a bug or resolves a feature request, be sure to link to that issue. If not, delete the next line. -->
+
+Closes #n.
+
+## Test plan
+
+<!-- Demonstrate the code is solid. Example: The exact steps you followed to test it and their outcome. -->
+
+## Screenshots
+
+<!--- Add screenshots/videos if the pull request changes UI. If not, delete this entire section. -->
+
+## Further comments
+
+<!--- Kick of a discussion about this change, if applicable. If not, delete this entire section. -->


### PR DESCRIPTION
## Summary

Added [GitHub templates](https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates) for Issues and Pull request templates to standardize the information collected from devs. Templates are a great tool to **help everyone in the team write better issues and pull requests**.

Once this lands on `master`, the templates will become active. For issues, a nice template chooser will be presented to the developer when clicking "New issue". For Pull requests, the description will be automatically populated with the template when clicking "New pull request".
